### PR TITLE
ci: reintroduce major tag move

### DIFF
--- a/.github/workflows/merge-semver-tag.yml
+++ b/.github/workflows/merge-semver-tag.yml
@@ -45,3 +45,4 @@ jobs:
         with:
           tag: ${{ steps.calculate.outputs.version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          move_major_tag: true


### PR DESCRIPTION
This change reintroduces the `move_major_tag`, this ensures that we have a v1 that can be pegged against and move in sync with the appropriate version.